### PR TITLE
Trigger onContentChange when clicking on markdown buttons

### DIFF
--- a/src/MarkdownEditor.js
+++ b/src/MarkdownEditor.js
@@ -356,10 +356,10 @@ var MarkdownEditor = React.createClass({
     var beforeSelectionContent = text.slice(0, selection.selectionStart);
     var afterSelectionContent = text.slice(selection.selectionEnd, text.length);
     var updatedText = token.applyTokenTo(selection.selectedText);
-
     var _updatedContent = beforeSelectionContent + updatedText + afterSelectionContent;
     PublicMarkdownEditorActions.updateText(MarkdownUtils.toMarkdown(_updatedContent));
     this.setState({content: _updatedContent});
+    this.props.onContentChange(_updatedContent);
   },
 
   generateMarkdownToken: function(actionType) {


### PR DESCRIPTION
Adding  **this.props.onContentChange(_updatedContent);** to the updateText function in order to trigger onContentChange listener when applying markdowns. Some people may apply some markdowns after writing up text so it may be better to trigger the onContentChange listener when clicking on the markdown buttons.  
